### PR TITLE
Fix no case clause matching

### DIFF
--- a/src/leo_watchdog.erl
+++ b/src/leo_watchdog.erl
@@ -127,7 +127,9 @@ handle_info(timeout, #state{id = Id,
                                  {line, ?LINE}, {body, {CallbackMod, Reason}}]),
                               Props;
                           {_, NewProps} ->
-                              NewProps
+                              NewProps;
+                          _ ->
+                              Props
                       end;
                   {_Ret, NewProps} ->
                       catch ets:insert(Id, NewProps),


### PR DESCRIPTION
`leo_watchdog_foo:handle_fail` returns ok atom.
This does not match any cases in `leo_watchdog:handle_info`.
