### PR TITLE
Show system statistics as info logs

### DIFF
--- a/src/leo_watchdog_cpu.erl
+++ b/src/leo_watchdog_cpu.erl
@@ -139,6 +139,11 @@ handle_call(Id, #state{threshold_load_avg = ThresholdLoadAvg,
                          false -> ?WD_LEVEL_WARN
                      end,
 
+        error_logger:info_msg("~p,~p,~p,~p~n",
+                              [{module, ?MODULE_STRING},
+                               {function, "handle_call/2"},
+                               {line, ?LINE}, {body, {ThresholdLoadAvg, AVG_1, AVG_5}}]),
+
         %% Load avg
         Level_1 = case (ThresholdLoadAvg * 100 < AVG_1 orelse
                         ThresholdLoadAvg * 100 < AVG_5) of
@@ -165,6 +170,11 @@ handle_call(Id, #state{threshold_load_avg = ThresholdLoadAvg,
                           elarm:clear(Id, ?WD_ITEM_LOAD_AVG),
                           ?WD_LEVEL_SAFE
                       end,
+
+        error_logger:info_msg("~p,~p,~p,~p~n",
+                              [{module, ?MODULE_STRING},
+                               {function, "handle_call/2"},
+                               {line, ?LINE}, {body, {ThresholdCpuUtil, CPU_Util}}]),
 
         %% CPU util
         Level_2 = case (CPU_Util > ThresholdCpuUtil) of

--- a/src/leo_watchdog_disk.erl
+++ b/src/leo_watchdog_disk.erl
@@ -339,6 +339,10 @@ disk_stats_1({ok, #disk_stat{util = Util,
                       true  -> ?WD_LEVEL_ERROR;
                       false -> ?WD_LEVEL_WARN
                   end,
+    error_logger:info_msg("~p,~p,~p,~p~n",
+                          [{module, ?MODULE_STRING},
+                           {function, "disk_stats_1/2"},
+                           {line, ?LINE}, {body, {ThresholdDiskUtil, Util}}]),
 
     State_1 = case (Util >  ThresholdDiskUtil) of
                   true ->
@@ -354,6 +358,13 @@ disk_stats_1({ok, #disk_stat{util = Util,
                       elarm:clear(Id, ?WD_ITEM_DISK_UTIL),
                       [{?WD_ITEM_DISK_UTIL, ?WD_LEVEL_SAFE}]
               end,
+
+    error_logger:info_msg("~p,~p,~p,~p~n",
+                          [{module, ?MODULE_STRING},
+                           {function, "disk_stats_1/2"},
+                           {line, ?LINE},
+                           {body, {(ThresholdRkb + ThresholdWkb), (Rkb + Wkb)}}]),
+
     State_2 = case ((Rkb + Wkb) > (ThresholdRkb + ThresholdWkb)) of
                   true ->
                       elarm:raise(

--- a/src/leo_watchdog_io.erl
+++ b/src/leo_watchdog_io.erl
@@ -124,6 +124,11 @@ handle_call(Id, #state{threshold_input   = ThresholdInput,
     ThresholdIO = erlang:round((ThresholdInput + ThresholdOutput)
                                * Interval / 1000),
 
+    error_logger:info_msg("~p,~p,~p,~p~n",
+                          [{module, ?MODULE_STRING},
+                           {function, "handle_call/2"},
+                           {line, ?LINE}, {body, {ThresholdIO, CurTotalIO}}]),
+
     case (CurTotalIO > ThresholdIO) of
         true ->
             elarm:raise(Id, ?WD_ITEM_IO,

--- a/src/leo_watchdog_rex.erl
+++ b/src/leo_watchdog_rex.erl
@@ -99,6 +99,11 @@ handle_call(_Id, #state{max_mem_capacity = MemCapacity} = State) ->
             {{error, not_running}, State};
         Pid ->
             BinaryMem = erlang:memory(binary),
+            error_logger:info_msg("~p,~p,~p,~p~n",
+                                  [{module, ?MODULE_STRING},
+                                   {function, "handle_call/2"},
+                                   {line, ?LINE},
+                                   {body, {MemCapacity, BinaryMem}}]),
             case (BinaryMem >= MemCapacity) of
                 true ->
                     erlang:garbage_collect(Pid);


### PR DESCRIPTION
This commit adds info logs of CPU, Disk and Memory stats.
It's useful for check watchdog status and system status.

Please note that this will produce big log continuously.
It's reasonable to disable this when it's not needed.
