### PR TITLE
Fix tpyo in comment sentence from @dog to @doc

### DIFF
--- a/src/leo_watchdog_cluster.erl
+++ b/src/leo_watchdog_cluster.erl
@@ -103,7 +103,7 @@ update_property(_,_, State) ->
     State.
 
 
-%% @dog Call execution of the watchdog
+%% @doc Call execution of the watchdog
 -spec(handle_call(Id, State) ->
              {ok, State} |
              {{error,Error}, State} when Id::atom(),
@@ -153,7 +153,7 @@ handle_call(Id, #state{check_cluster_state_mfa = CheckClusterStateMFA} = State) 
     {ok, State}.
 
 
-%% @dog Call execution failed
+%% @doc Call execution failed
 -spec(handle_fail(Id, Cause) ->
              ok | {error,Error} when Id::atom(),
                                      Cause::any(),

--- a/src/leo_watchdog_cpu.erl
+++ b/src/leo_watchdog_cpu.erl
@@ -133,7 +133,7 @@ update_property(_,_, State) ->
     State.
 
 
-%% @dog Call execution of the watchdog
+%% @doc Call execution of the watchdog
 -spec(handle_call(Id, State) ->
              {ok, State} | {{error,Error}, State} when Id::atom(),
                                                        State::#state{},
@@ -245,7 +245,7 @@ handle_call(Id, #state{threshold_load_avg = ThresholdLoadAvg,
             {ok, State}
     end.
 
-%% @dog Call execution failed
+%% @doc Call execution failed
 -spec(handle_fail(Id, Cause) ->
              ok | {error,Error} when Id::atom(),
                                      Cause::any(),

--- a/src/leo_watchdog_disk.erl
+++ b/src/leo_watchdog_disk.erl
@@ -259,7 +259,7 @@ update_property(_,_, State) ->
     State.
 
 
-%% @dog Call execution of the watchdog
+%% @doc Call execution of the watchdog
 -spec(handle_call(Id, State) ->
              {ok, State} | {{error,Error}, State} when Id::atom(),
                                                        State::#state{},
@@ -270,7 +270,7 @@ handle_call(Id, #state{target_paths  = TargetPaths} = State) ->
     {ok, State_1}.
 
 
-%% @dog Call execution failed
+%% @doc Call execution failed
 -spec(handle_fail(Id, Cause) ->
              ok | {error,Error} when Id::atom(),
                                      Cause::any(),

--- a/src/leo_watchdog_io.erl
+++ b/src/leo_watchdog_io.erl
@@ -114,7 +114,7 @@ update_property(_,_, State) ->
     State.
 
 
-%% @dog Call execution of the watchdog
+%% @doc Call execution of the watchdog
 -spec(handle_call(Id, State) ->
              {ok, State} |
              {{error,Error}, State} when Id::atom(),
@@ -165,7 +165,7 @@ handle_call(Id, #state{threshold_input   = ThresholdInput,
     end.
 
 
-%% @dog Call execution failed
+%% @doc Call execution failed
 -spec(handle_fail(Id, Cause) ->
              ok | {error,Error} when Id::atom(),
                                      Cause::any(),

--- a/src/leo_watchdog_rex.erl
+++ b/src/leo_watchdog_rex.erl
@@ -97,7 +97,7 @@ update_property(_,_, State) ->
     State.
 
 
-%% @dog Call execution of the watchdog
+%% @doc Call execution of the watchdog
 -spec(handle_call(Id, State) ->
              {ok, State} |
              {{error, Error}, State} when Id::atom(),
@@ -119,7 +119,7 @@ handle_call(_Id, #state{max_mem_capacity = MemCapacity} = State) ->
     end.
 
 
-%% @dog Call execution failed
+%% @doc Call execution failed
 -spec(handle_fail(Id, Cause) ->
              ok | {error,Error} when Id::atom(),
                                      Cause::any(),


### PR DESCRIPTION
I found a little bit of typo in comment sentence. So I change sentence from @dog to @doc. Please review it.

Thanks.
