### PR TITLE
Make gen_server terminate without errors

### DIFF
--- a/src/leo_watchdog_sup.erl
+++ b/src/leo_watchdog_sup.erl
@@ -56,7 +56,7 @@ stop() ->
 stop_1([]) ->
     ok;
 stop_1([{NamedProc,_Pid,worker,_}|Rest]) ->
-    _ = leo_watchdog:stop(NamedProc),
+    supervisor:terminate_child(?MODULE, NamedProc),
     stop_1(Rest).
 
 


### PR DESCRIPTION
Part of fix for https://github.com/leo-project/leofs/issues/960